### PR TITLE
feat: add CoSAI Week in Review section and fix Drive fetch for loose Gemini docs

### DIFF
--- a/TSC Meeting Planner and Tracker/meetings/2026-09-01.md
+++ b/TSC Meeting Planner and Tracker/meetings/2026-09-01.md
@@ -16,8 +16,8 @@
 
 | Item | Notes |
 |---|---|
-| Deadlines | - AIMM Paper TSC & PGB Full Majority Vote — target date 2026-08-23 (past due; status check needed) <br> - Zero Trust Paper TSC & PGB Review — target date 2026-08-23 (past due; status check needed) <br> - Agentic Isolation Blog — published 2026-08-25 ✅ <br> - TSC Co-Chair Election: outcome pending — next steps to be discussed under New Topics |
-| Polls | - TSC Co-Chair Election ballot — closed EOB Friday 2026-08-28; outcome not yet decided (see New Topics #7) |
+| Deadlines | - Transition of Co-Chair Responsibilities: first discussion meeting today (2026-09-01); second discussion at 2026-09-08 meeting |
+| Polls | - TSC Co-Chair Election ballot: closed EOB 2026-08-28 — outcome to be announced <br> - WS1 AIMM Paper & WS2 Zero Trust Paper approval ballot: voting members urged to cast votes during the week of 2026-08-25; outcome pending |
 | Any OASIS announcements | |
 
 ---
@@ -32,13 +32,16 @@
 
 | # | Issue | Topic | Proposer / Source | Status |
 |---|---|---|---|---|
-| 1 | #49 | **End of Term Review** — workstream and SIG standup ahead of co-chair transition (WS1, WS2, WS3, WS4, CoSAI-RM SIG, Code SIG, ADLC SIG); co-chair transition discussion | J.R. Rao, Akila Srinivasan | 🔄 Under Discussion |
-| 2 | #44 | **Ballot outcomes status check** — results of WS1 AIMM Paper and WS2 Zero Trust Paper ballots; co-chair election results | Claudia Rauch | 🔄 Under Discussion |
-| 3 | #48 | **Consensus Industry Framework for AI Jailbreaks** — Josiah Hagen to present one-page summary; TSC discussion on SIG or workstream home ⚠️ Carried Over (not reached 2026-08-25) | Josiah Hagen / 2026-08-18 minutes | 🔄 Under Discussion |
-| 4 | #50 | **CoSAI-RM Component Rework — alternative feedback pathways** — live blocker: WS4 cannot proceed with decomposition until components are established; zero async feedback received ⚠️ Carried Over (not reached 2026-08-25) | David LaBianca / 2026-08-18 minutes | 🔄 Under Discussion |
-| 5 | #51 | **Telemetry Paper GitHub migration and CoSAI-RM branch alignment** — confirm TSC guidance on WIP labeling for public GitHub drafts; David LaBianca to share pre-review branch ⚠️ Carried Over (not addressed 2026-08-25) | Josiah Hagen / 2026-08-18 minutes | 🔄 Under Discussion |
-| 6 | #53 | **Academic publishing pathway (arXiv)** — confirm whether to pursue arXiv; confirm assignment of exploration task to marketing committee | Josiah Hagen | 🔄 Under Discussion |
-| 7 | #44 | **TSC Co-Chair Election — Next Steps** — election outcome not yet decided; TSC to discuss next steps with Claudia Rauch and OASIS | Claudia Rauch / OASIS | 🔄 Under Discussion |
+| 1 | #49 | End of Term Review — workstream and SIG standup ahead of co-chair transition (scheduled for this meeting) | Akila Srinivasan; reaffirmed 2026-08-25 | 🔄 Under Discussion |
+| 2 | #44 | Ballot outcomes status check — WS1/WS2 papers and co-chair election | TSC voting members / Claudia Rauch | 🔄 Under Discussion |
+| 3 | #50 | CoSAI-RM component rework — alternative feedback pathways (not reached on 2026-08-25; live blocker for WS4) | David LaBianca | 🔄 Under Discussion |
+| 4 | #48 | Consensus Industry Framework for AI Jailbreaks — Josiah Hagen to present one-page summary; TSC to determine SIG or workstream home (not reached on 2026-08-25) | Josiah Hagen | 🔄 Under Discussion |
+| 5 | #51 | Telemetry Paper GitHub migration and CoSAI-RM branch alignment — confirm TSC guidance on WIP labeling in public repos | Josiah Hagen / 2026-08-18 minutes | 🔄 Under Discussion |
+| 6 | #53 | Academic publishing pathway (arXiv) — confirm marketing committee as owner and resolve open questions on neutrality, style conversion, and attribution | J.R. Rao / 2026-08-25 minutes | 🔄 Under Discussion |
+| 7 | #52 | Reassess workstream scope, goals, and roadmaps — scheduled for 2026-09-08; preview/confirm scope and WS2 recalibration proposal | Claudia Rauch; supported by Asmae Mhassni | 🔄 Under Discussion |
+| 8 | | WS4 state-of-the-working-group report — Sarah Novotny to present upcoming deliverables and target timelines (WS4 committed to present at this meeting) | WS4 / 2026-08-27 minutes | 🔄 Under Discussion |
+| 9 | | ADLC SIG leadership gap and P0 priority alignment — two leads stepped back; group paused RFC work pending check-in with Ian Molloy and Sarah Novotny on sandboxing vs. lifecycle paper priority | ADLC SIG / WS4 2026-08-27 minutes | 🔄 Under Discussion |
+| 10 | | Cross-workstream consolidation question: Agent Credentials Group and WS1 — proposal raised to merge parallel workstreams; Nicolai Nielsen suggested TSC / Claudia input on how to unify | Agent Credentials Group / 2026-08-27 minutes | 🔄 Under Discussion |
 
 **Status Key:** ✅ Confirmed · 🔄 Under Discussion · ❌ Deferred
 
@@ -46,60 +49,72 @@
 
 ## 3. Review of Previous Action Items
 
-> Action items from recent TSC meeting minutes and open Issues labeled
-> `action-item`. Items marked ✅ are resolved — they appear this week
+> Action items from open Issues labeled `action-item` and recent TSC
+> meeting minutes. Items marked ✅ are resolved — they appear this week
 > for visibility and drop off next week.
 > ⏱ Time budget: 15 minutes
 
 | Source | Action Item | Owner | Due | Status |
 |---|---|---|---|---|
-| #46 | Create workstream review template for End of Term standup (needed for this meeting) | Akila Srinivasan | Before 2026-09-01 | ❓ Unknown |
-| #45 | Present telemetry documentation to Workstream 4 — Secure Design Patterns for Agentic Systems for feedback | Sarah Novotny | None stated | ❓ Unknown |
-| #47 | Develop regional meetup / community workshop proposal | J.R. Rao, Akila Srinivasan | None stated | ⚠️ Carried Over |
-| 2026-08-18 minutes | Nominate TSC co-chairs — submit self-nominations to Claudia by EOD Thursday 2026-08-21 | The group | 2026-08-21 | ✅ Done — co-chair ballot opened and closed EOB 2026-08-28; results due this meeting (see #44) |
-| 2026-08-18 minutes | Provide blog feedback — review Ian Molloy's Agentic Isolation Blog draft re: detection and recovery approach | David LaBianca | 2026-08-21 | ✅ Done — Sarah reported David L.'s feedback was incorporated into final edits (2026-08-25 minutes) |
-| 2026-08-18 minutes | Notify marketing committee — inform marketing committee about ongoing paper review period | Claudia Rauch | | ✅ Done — Claudia confirmed the marketing committee was notified to prepare publication schedules (2026-08-25 minutes) |
-| 2026-08-18 minutes | Jailbreak Framework write-up — draft one-page summary on consensus industry framework for jailbreaks including potential CoSAI directions | Josiah Hagen | | ❓ Unknown |
-| 2026-08-18 minutes | Present jailbreak framework to Workstream 2 — Preparing Defenders for a Changing Cybersecurity Landscape | Josiah Hagen | | ❓ Unknown |
-| 2026-08-18 minutes | Share branch — provide branch containing pre-review risks and controls to align Telemetry Paper mapping | David LaBianca | | ❓ Unknown |
-| 2026-08-18 minutes | Organize feedback sessions — schedule smaller group sessions or longer meetings to gather synchronous feedback on CoSAI-RM components | David LaBianca | | ❓ Unknown |
-| 2026-08-11 minutes | Review arXiv as publication option — consult internally to determine feasibility of publishing CoSAI deliverables on arXiv | Claudia Rauch | | 🔄 In Progress — revisited 2026-08-25 (neutrality and style-conversion concerns raised); no decision, see #53 |
-| 2026-08-11 minutes | Integrate citation methodology — incorporate citation impact findings into organizational workflow | J.R. Rao, Karttik Panda | | 🔄 In Progress — citation list merged into the TSC repository, maintained by Karttik (2026-08-25 minutes) |
-| 2026-08-11 minutes | Map Zero Trust Paper — meet with Shrey and David to align Zero Trust Paper with CoSAI-RM | Josiah Hagen, Jason Garman | | ✅ Done — Josiah confirmed mapped controls conform to the latest version (2026-08-25 minutes) |
-| 2026-08-11 minutes | Update Zero Trust Paper — incorporate reviewer feedback from Akila Srinivasan | Josiah Hagen | | ❓ Unknown |
-| 2026-08-11 minutes | Add sandbox policy — surgically update risk map and Zero Trust Paper to include sandbox policy enforcement elements | The group | | ⚠️ Carried Over — Jason and Josiah scoped sandboxing/isolation out of the Zero Trust Paper; picked up by WS4 and the ADLC sync (2026-08-25 minutes) |
-| 2026-08-11 minutes | Prepare Containment Content — draft point of view document on isolation and containment for WS4 agenda | Ian Molloy, Sarah Novotny | | ✅ Done (addressed as Agentic Isolation Blog) — published 2026-08-25; deeper explorations deferred to a follow-up paper |
-| 2026-08-11 minutes | Prepare WS Status Review — review status of workstreams and SIGs ahead of TSC leadership transition ⚠️ Carried Over (2 meetings) | The group | | ❓ Unknown |
+| #46 | Create workstream review template for End of Term Review standup | Akila Srinivasan | Before 2026-09-01 | 🔄 In Progress |
+| #45 | Present telemetry documentation to Workstream 4 for review and feedback | Sarah Novotny | None stated | 🔄 In Progress |
+| #47 | Develop regional meetup / community workshop proposal | J.R. Rao, Akila Srinivasan | None stated | 🔄 In Progress |
+| 2026-08-25 minutes | Vote on open ballots: WS1 AIMM Paper and WS2 Zero Trust Paper approval | TSC voting members | Week of 2026-08-25 | ❓ Unknown |
+| 2026-08-25 minutes | Post ballot links: share links for WS1 and WS2 approval ballots in communication channel | Claudia Rauch | 2026-08-25 | ✅ Done |
+| 2026-08-18 minutes | Provide blog feedback on detection and recovery approach before Thursday deadline | David LaBianca | 2026-08-21 (deadline passed) | ✅ Done |
+| 2026-08-18 minutes | Send review email for the two papers to TSC and PGB lists | Claudia Rauch | 2026-08-18 | ✅ Done |
+| 2026-08-18 minutes | Notify marketing committee about ongoing paper review period | Claudia Rauch | 2026-08-18 | ✅ Done |
+| 2026-08-18 minutes | Jailbreak Framework Write-up: draft one-page summary on consensus industry framework for jailbreaks | Josiah Hagen | Before 2026-09-01 TSC | ❓ Unknown |
+| 2026-08-18 minutes | Present jailbreak framework discussion to Workstream 2 | Josiah Hagen | Before 2026-09-01 TSC | ❓ Unknown |
+| 2026-08-18 minutes | Share branch containing pre-review risks and controls to align Telemetry Paper mapping | David LaBianca | None stated | ❓ Unknown |
+| 2026-08-18 minutes | Organize feedback sessions: schedule smaller group sessions or longer meetings to gather synchronous feedback on CoSAI-RM components | David LaBianca | None stated | ❓ Unknown |
+| 2026-08-18 minutes | Submit self-nominations or nominations for TSC co-chairs to Claudia | The group | EOB 2026-08-21 | ✅ Done |
 
 **Status Key:** ✅ Done · 🔄 In Progress · ⚠️ Carried Over · ❓ Unknown
 
 ---
 
-## 4. Active Deliverables Snapshot
+## 4. CoSAI Week in Review
+
+> A summary of what was discussed across CoSAI Workstreams and SIGs
+> since the last TSC meeting. Sourced from meeting minutes files dated
+> within the last 14 days. Groups that did not meet are noted explicitly.
+
+| Group | Last Met | Summary |
+|---|---|---|
+| WS1 — Software Supply Chain Security for AI Systems | 2026-08-26 | The group focused on scoping transportable evidence for AI/ML artifacts, adopting GitHub Issue 31 as the central location for community input and scenario brainstorming. A regulated banking use case was proposed as the initial bounded scope, with data sovereignty established as a required constraint. The group decided to delegate standards mapping to WS3, and discussed alignment with external bodies such as OpenTelemetry, OCSF, and W3C agent credentials to ensure adoption. Cross-workstream collaboration with the Agent Credentials group is planned, including coordination with Imran on agent trust work. |
+| WS2 — Preparing Defenders for a Changing Cybersecurity Landscape | Did not meet | Did not meet |
+| WS3 — AI Security Risk Governance | 2026-08-20 | The group completed the threat model for the AI code review agent and progressed secure AI tooling pull requests. A draft PR containing new components for the MCP paper was prepared, with a preview branch shared with Josiah Hagen to assist telemetry paper alignment; seven issues for WS4 review were targeted. The team decided to remove unusable control and risk graphs from the repository, retaining only component graphs. Dependabot was integrated to automate pre-commit dependency management. The ADLC SIG was noted as actively reviewing the MCP components preview branch. |
+| WS4 — Secure Design Patterns for Agentic Systems | 2026-08-27 | WS4 confirmed that the agentic isolation blog post (Issue 167) is complete and in the repository awaiting marketing publication. Version 2 of the MCP Security White Paper was published. The group prioritized completion of a foundational ADLC definitional lifecycle paper before integrating specific risks and controls. ADLC leadership gaps were identified, with Sarah Novotny coordinating succession. Imran Siddique presented an agent manifest RFC, and the group discussed reconciling it with agent credentials work. The working group committed to presenting a state-of-the-group report with upcoming deliverables at the September 1 TSC meeting. TSC reviewers for the containment follow-on paper were requested. |
+| CoSAI-RM SIG — Coalition for Secure AI Risk Map | 2026-08-26 | The SIG focused on pull request workflow alignment, merging PR 473 (components) into the develop branch to enable WS4 review of upcoming risks and controls. PR 497 scope was narrowed to avoid blocking progress, with secondary improvements deferred to a follow-up issue. The team completed CI updates requiring every agent and skill to ship with evaluations and adding neutrality scanning. Control and risk graph generation (~8,000 lines of code) was deprecated as unusable. David LaBianca outlined upcoming domain-specific issues for WS4 to review MCP-driven controls and risks. |
+| Code SIG — Security of AI-Assisted Code Generation | 2026-08-25 | The SIG discussed Code Guard modernization to reduce context window usage and address outdated rule structure. APM (Agent Package Manager) support was designated as an optional pathway only. A new security evaluation harness using two Docker containers was implemented to benchmark Code Guard performance before and after updates, with plans to expand testing to local open-source models. Meeting attendance was at a historic low; a cadence review (bi-weekly or shorter sessions) was deferred to September. The security of publicly distributed AI skills was identified as an open industry problem outside the SIG's current scope. |
+| ADLC SIG — Security of Agent Development Lifecycle | 2026-08-26 | The group debated hard versus soft decommissioning, ultimately scoping the decommissioning RFC to hard decommissioning only, though regulatory data retention requirements (forensic, archival) remain unresolved and require further feedback. Observability was reclassified as a top-level component category rather than a lifecycle stage. David LaBianca raised concerns that the group was skipping foundational steps by not first producing a lifecycle definition paper. The group paused new RFC filings to re-evaluate ADLC process and P0 priorities with Ian Molloy and Sarah Novotny, with sandboxing identified as a potential primary focus following recent sandbox escape incidents. |
+| Agent Credentials Group | 2026-08-27 | The group refined the credential definition to "a signed claim bound to a subject and intended for downstream verification," with appraisal confirmed as not required. Document review flagged inaccurate RFC citations in AI-generated sections. A cross-workstream alignment proposal was raised to merge WS1 and WS4 threads dealing with verifiable claims and transportable evidence, citing fragmented consumer experience and split participant energy; Claudia was suggested as a resource for strategic guidance on workstream consolidation. A financial use case from Jamilu Abdullahi is being explored as a reference implementation in the agent credentials paper. |
+
+---
+
+## 5. Active Deliverables Snapshot
 > Sourced from `TSC Deliverables/roadmap.md`. Updated after each TSC meeting.
 > Items in active review or vote stages are surfaced as agenda topics in
 > Section 2. This snapshot is for at-a-glance awareness only.
 
 | # | Deliverable | Workstream / SIG | Current Stage | Next Deadline | Next Milestone |
 |---|---|---|---|---|---|
-| 1 | Election and Appointment of New TSC Co-Chairs | TSC | 🗳️ TSC Vote | 2026-08-28 | Election closed EOB Friday — results at this meeting |
-| 2 | Transition of Co-Chair Responsibilities | TSC | 🔵 Planned | 2026-09-01 & 2026-09-08 | Transition discussions at Sept 1 and Sept 8 meetings |
-| 3 | AIMM Paper | WS1 — Software Supply Chain Security for AI Systems | 🟤 TSC & PGB Full Majority Vote | 2026-08-23 | TSC & PGB Full Majority Vote |
-| 4 | Zero Trust Paper | WS2 — Preparing Defenders for a Changing Cybersecurity Landscape | 🔴 TSC & PGB Review | 2026-08-23 | TSC & PGB Full Majority Vote |
+| 1 | Election and Appointment of New TSC Co-Chairs | TSC | 🗳️ TSC Vote | 2026-08-28 | Outcome to be announced |
+| 2 | Transition of Co-Chair Responsibilities | TSC | 🔵 Planned | 2026-09-01 & 2026-09-08 | Transition discussions |
+| 3 | AIMM Paper | WS1 — Software Supply Chain Security for AI Systems | 🟤 TSC & PGB Full Majority Vote | TBD | Outcome pending |
+| 4 | Zero Trust Paper | WS2 — Preparing Defenders for a Changing Cybersecurity Landscape | 🔴 TSC & PGB Review | TBD | TSC & PGB Full Majority Vote |
 | 5 | Telemetry Paper | WS2 — Preparing Defenders for a Changing Cybersecurity Landscape | 🔵 In Progress | TBD | TSC Co-chairs Review |
-| 6 | Agentic Isolation Blog | WS4 — Secure Design Patterns for Agentic Systems | 🟢 Published / Complete | | Published 2026-08-25 |
+| 6 | Agentic Isolation Blog | WS4 — Secure Design Patterns for Agentic Systems | 🟢 Published / Complete | | Published |
 
 > **Stage Key:** 🔵 Planned · 🔵 In Progress · 🟡 TSC Co-chairs Review ·
 > 🟠 TSC Review · 🔴 TSC & PGB Review · 🟣 Consensus Review ·
 > 🟤 TSC & PGB Full Majority Vote · 🗳️ TSC Vote · 🟢 Published / Complete
 
-> ⚠️ Deliverables with target dates within the next 4 weeks:
-> All six active deliverables have deadlines at or before 2026-09-01. AIMM Paper (🟤 TSC & PGB Full Majority Vote, target 2026-08-23) and Zero Trust Paper (🔴 TSC & PGB Review, target 2026-08-23) are past their target dates and require status checks. Agentic Isolation Blog published 2026-08-25 ✅. Transition of Co-Chair Responsibilities discussions are scheduled for this meeting and 2026-09-08.
-
 ---
 
-## 5. Workstream and SIG Updates
-> **Fallback item** — covered if time permits after items 1–4.
+## 6. Workstream and SIG Updates
+> **Fallback item** — covered if time permits after items 1–5.
 > Chairs will decide at the meeting whether to include this section.
 > **This section should be scheduled as a standing item at least once
 > a month** to ensure all workstreams and SIGs have regular visibility
@@ -114,6 +129,11 @@ Brief updates from leads as available:
 - **CoSAI-RM SIG — Coalition for Secure AI Risk Map:**
 - **Code SIG — Security of AI-Assisted Code Generation:**
 - **ADLC SIG — Security of Agent Development Lifecycle:**
+
+> ⚠️ Deliverables with target dates within the next 4 weeks:
+> - **Transition of Co-Chair Responsibilities** (TSC) — transition discussions scheduled 2026-09-01 and 2026-09-08
+> - **AIMM Paper** (WS1) — TSC & PGB Full Majority Vote in progress; original target was 2026-08-23
+> - **Zero Trust Paper** (WS2) — TSC & PGB Review in progress; original target was 2026-08-23
 
 ---
 

--- a/scripts/fetch_meeting_minutes.py
+++ b/scripts/fetch_meeting_minutes.py
@@ -3,9 +3,14 @@
 Fetch CoSAI meeting minutes from Google Drive and GitHub, save as markdown.
 
 Drive sources: Reads Gemini-generated meeting notes from shared Drive
-folders, exports them as markdown. Drive access goes through the Google
-Workspace CLI (`gws`, https://github.com/googleworkspace/cli). See
-scripts/README.md for one-time gws + gcloud + OAuth setup. Currently covers
+folders, exports them as markdown. Each Drive source is scanned three ways:
+per-meeting subfolders, loose notes documents sitting directly in the parent
+folder, and a shared-with-me fallback. Drive access goes through the Google
+Workspace CLI (`gws`, https://github.com/googleworkspace/cli). See the
+"TSC Meeting Planner and Tracker" README for one-time gws + OAuth setup;
+an expired token surfaces as `token_valid: false` in `gws auth status` and
+makes every Drive source silently stale — re-run `gws auth login`.
+Currently covers
 WS1, WS2, WS3, WS4, the ADLC SIG (under WS4), the Code-Development SIG
 (under WS3), the Risk Management SIG (under WS3), and the Agent Credentials
 group.
@@ -82,10 +87,13 @@ SOURCES = [
         "type": "drive",
         "folder_id": "1L7A46unF12D3Tk68_QVP53M9cGjJUMA3",
         "subdir": "ws1",
-        # Prefix match — works whether or not "Notes by Gemini" is appended
-        "shared_name_contains": "CoSAI WS1 Weekly Meeting",
+        # Prefix match — works whether or not "Notes by Gemini" is appended.
+        # The meeting was renamed from "CoSAI WS1 Weekly Meeting" to
+        # "CoSAI WS1 Meeting (updated)"; match both so older titles keep working.
+        # Narrowest substring common to both old and new titles.
+        "shared_name_contains": "CoSAI WS1",
         "shared_title_pattern": (
-            r"^CoSAI WS1 Weekly Meeting - "
+            r"^CoSAI WS1 (?:Weekly )?Meeting(?: \(updated\))?\s+- "
             r"(?P<y>\d{4})/(?P<m>\d{2})/(?P<d>\d{2})"
         ),
         "shared_folder_name_template": "WS1-{y}{m}{d}",
@@ -95,11 +103,14 @@ SOURCES = [
         "type": "drive",
         "folder_id": "1zmeLjxAp8UJdu99LM3qAhHf-CH9JGR32",
         "subdir": "ws2",
-        # Prefix match — WS2 files end after the date with no "Notes by Gemini"
-        "shared_name_contains": "CoSAI WS2 Defenders meeting",
+        # Prefix match — WS2 files end after the date with no "Notes by Gemini".
+        # Titles are now "CoSAI WS2 Defenders Bi-Weekly Meeting". Some older
+        # entries separate the date with "/" in the day position (2026/05-19),
+        # so accept "/" or "-" between date parts.
+        "shared_name_contains": "CoSAI WS2 Defenders",
         "shared_title_pattern": (
-            r"^CoSAI WS2 Defenders meeting - "
-            r"(?P<y>\d{4})/(?P<m>\d{2})/(?P<d>\d{2})"
+            r"^CoSAI WS2 Defenders (?:Bi-Weekly )?[Mm]eeting\s+- "
+            r"(?P<y>\d{4})[/-](?P<m>\d{2})[/-](?P<d>\d{2})"
         ),
         "shared_folder_name_template": "WS2-{y}{m}{d}",
     },
@@ -108,8 +119,14 @@ SOURCES = [
         "type": "drive",
         "folder_id": "1NFk_-2Plyi3qYr2qtrvt42AQhzJZB0Wf",
         "subdir": "ws3",
-        # No shared-with-me fallback: WS3 docs aren't Gemini-tagged with a
-        # stable title pattern. The folder-walk pass picks them up instead.
+        # Titles are "WS3 bi-weekly meeting  - <date>" — note the double space
+        # before the dash, hence \s+ rather than a literal " ".
+        "shared_name_contains": "WS3 bi-weekly meeting",
+        "shared_title_pattern": (
+            r"^WS3 bi-weekly meeting\s+- "
+            r"(?P<y>\d{4})/(?P<m>\d{2})/(?P<d>\d{2})"
+        ),
+        "shared_folder_name_template": "WS3-{y}{m}{d}",
     },
     {
         "name": "WS4",
@@ -317,8 +334,13 @@ def folder_name_to_filename(folder_name):
 
     e.g. 'WS4-20260402' → 'WS4-20260402.md'
          'WS1 20260402' → 'WS1-20260402.md'
+
+    Path separators and other characters that are unsafe in filenames are
+    replaced with '-', so a raw Gemini document title can be passed in safely.
     """
     name = re.sub(r"\s+", "-", folder_name.strip())
+    name = re.sub(r'[/\\:*?"<>|]', "-", name)
+    name = re.sub(r"-{2,}", "-", name).strip("-")
     return f"{name}.md"
 
 
@@ -366,6 +388,80 @@ def fetch_drive_source(source, output_dir, skip_existing):
         fetched += 1
 
     return fetched, skipped, no_notes, errors
+
+
+def fetch_drive_loose_docs(source, output_dir, skip_existing):
+    """Catch notes that sit directly in the source's parent folder rather than
+    inside a per-meeting subfolder.
+
+    Gemini now drops "<meeting title> - YYYY/MM/DD HH:MM TZ - Notes by Gemini"
+    documents straight into the workstream folder. `fetch_drive_source` only
+    walks subfolders, and `fetch_drive_shared_fallback` only queries
+    `sharedWithMe`, which does not match files in a folder we can list
+    directly — so without this pass those notes are never fetched.
+
+    The output filename is derived from the date in the title via the same
+    `shared_folder_name_template` used by the shared-with-me fallback, so a
+    meeting filed into a subfolder later resolves to the same filename and is
+    skipped rather than duplicated.
+
+    Returns (fetched, skipped, errors).
+    """
+    pattern = source.get("shared_title_pattern")
+    template = source.get("shared_folder_name_template")
+    if not (pattern and template):
+        return 0, 0, 0
+
+    fetched = skipped = errors = 0
+    pat = re.compile(pattern)
+
+    print(f"\n[{source['name']}] Scanning parent folder for loose notes...")
+    try:
+        candidates = drive_list({
+            "q": (
+                f"'{source['folder_id']}' in parents and trashed=false and "
+                "mimeType='application/vnd.google-apps.document'"
+            ),
+            "fields": "nextPageToken, files(id, name, mimeType)",
+            "pageSize": 100,
+            "supportsAllDrives": True,
+            "includeItemsFromAllDrives": True,
+        })
+    except GwsError as e:
+        print(f"[{source['name']}] parent-folder listing failed ({e})",
+              file=sys.stderr)
+        return 0, 0, 1
+
+    for f in candidates:
+        m = pat.search(f["name"])
+        if not m:
+            continue
+        synthetic = template.format(**m.groupdict())
+        output_path = output_dir / folder_name_to_filename(synthetic)
+
+        if skip_existing and output_path.exists():
+            skipped += 1
+            continue
+
+        print(f"  [loose] {synthetic}: fetching '{f['name']}'...")
+        try:
+            content = export_doc_as_markdown(f["id"], output_dir)
+        except GwsError as e:
+            print(f"  [loose] {synthetic}: export failed ({e}); skipping",
+                  file=sys.stderr)
+            errors += 1
+            continue
+
+        header = (
+            f"# {synthetic}\n\n"
+            f"**Source:** {f['name']} (via parent-folder scan)\n\n"
+            f"---\n\n"
+        )
+        with open(output_path, "w") as out:
+            out.write(header + content)
+        fetched += 1
+
+    return fetched, skipped, errors
 
 
 def fetch_drive_shared_fallback(source, output_dir, skip_existing):
@@ -561,12 +657,18 @@ def main():
             )
             total_no_notes += no_notes
             total_errors += errors
-            f2, s2, e2 = fetch_drive_shared_fallback(
+            f2, s2, e2 = fetch_drive_loose_docs(
                 source, output_dir, args.skip_existing
             )
             fetched += f2
             skipped += s2
             total_errors += e2
+            f3, s3, e3 = fetch_drive_shared_fallback(
+                source, output_dir, args.skip_existing
+            )
+            fetched += f3
+            skipped += s3
+            total_errors += e3
 
         elif source["type"] == "github":
             fetched, skipped, errors = fetch_github_source(

--- a/scripts/generate_tsc_agenda.py
+++ b/scripts/generate_tsc_agenda.py
@@ -12,6 +12,9 @@ Context assembled:
   3. Open GitHub Issues labeled `action-item` — carry-over tasks needing status.
   4. TSC Deliverables/roadmap.md
   5. skills/cosai-tsc-meeting-agenda.md — used as the system prompt.
+  6. Week in Review material: the most recent minutes for each workstream and
+     SIG dated within WEEK_IN_REVIEW_WINDOW_DAYS of the meeting, with Last Met
+     dates computed here rather than inferred by the model.
 
 Non-TSC minutes (PGB, WS1-WS4, ADLC, ...) are passed with instructions to
 extract only TSC-relevant items rather than summarize the whole meeting.
@@ -31,7 +34,7 @@ import os
 import re
 import subprocess
 import sys
-from datetime import date
+from datetime import date, timedelta
 
 from dotenv import load_dotenv
 from anthropic import Anthropic
@@ -58,8 +61,38 @@ MEETINGS_OUT_DIR = os.path.join("TSC Meeting Planner and Tracker", "meetings")
 # a cross-stream source and filtered for TSC relevance only.
 TSC_SUBDIR = "tsc"
 
+# ── CoSAI Week in Review ─────────────────────────────────────────────────────
+# Section 4 of the agenda summarizes every workstream and SIG since the last TSC
+# meeting. Unlike the rest of the prompt — which extracts only TSC-relevant
+# items — this section needs an actual summary of each group's meeting, and it
+# must list all eight groups even when a group did not meet.
+#
+# Group labels must match the skill's Section 4 table rows exactly, in order.
+WEEK_IN_REVIEW_GROUPS = [
+    ("ws1", "WS1 — Software Supply Chain Security for AI Systems"),
+    ("ws2", "WS2 — Preparing Defenders for a Changing Cybersecurity Landscape"),
+    ("ws3", "WS3 — AI Security Risk Governance"),
+    ("ws4", "WS4 — Secure Design Patterns for Agentic Systems"),
+    ("rm-sig", "CoSAI-RM SIG — Coalition for Secure AI Risk Map"),
+    ("code-sig", "Code SIG — Security of AI-Assisted Code Generation"),
+    ("adlc", "ADLC SIG — Security of Agent Development Lifecycle"),
+    ("agent-credentials", "Agent Credentials Group"),
+]
+
+# A group's minutes count toward the Week in Review only if dated within this
+# many days of the meeting date. The skill defines the window as 14 days.
+WEEK_IN_REVIEW_WINDOW_DAYS = 14
+
+# How much of each in-window file to pass for summarization. Gemini notes lead
+# with a "Quick notes" digest and then repeat everything as a full transcript;
+# the digest is what a summary needs, and the transcripts run to ~500 KB each,
+# which would blow the context window if passed whole.
+WEEK_IN_REVIEW_EXCERPT_CHARS = 12000
+
 MODEL = "claude-sonnet-4-6"
-MAX_TOKENS = 4000
+# 4000 was sized before the agenda gained Section 4 CoSAI Week in Review, whose
+# eight summary rows push a full agenda past that cap and truncate Section 6.
+MAX_TOKENS = 8000
 
 
 # ── Repo root ────────────────────────────────────────────────────────────────
@@ -203,6 +236,133 @@ def read_recent_minutes(root: str) -> dict:
                   f"{', '.join(labels)}")
 
     return collected
+
+
+# ── CoSAI Week in Review ─────────────────────────────────────────────────────
+
+def parse_date_from_name(name: str):
+    """
+    Extract a date from a minutes filename, or None if it carries no date.
+
+    Handles both `YYYY-MM-DD.md` and `PREFIX-YYYYMMDD.md`. An impossible date
+    (e.g. a stray 8-digit run that is not a calendar date) returns None rather
+    than raising, so an oddly named file cannot abort the run.
+    """
+    match = DATE_IN_NAME.search(name)
+    if not match:
+        return None
+    try:
+        return date(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    except ValueError:
+        return None
+
+
+def collect_week_in_review(root: str, meeting_date: date) -> list:
+    """
+    Find the most recent in-window minutes file for each Week in Review group.
+
+    Returns one entry per group in WEEK_IN_REVIEW_GROUPS order, each a dict with
+    `subdir`, `label`, `last_met` (ISO date or None) and `excerpt`. A group with
+    no dated file inside the window gets last_met None, which the prompt renders
+    as "Did not meet" — the skill requires all eight groups to appear either way.
+
+    Undated files (topic-named aggregates like ws1/2025.md) are ignored: without
+    a date they cannot be placed inside or outside the window.
+    """
+    cutoff = meeting_date - timedelta(days=WEEK_IN_REVIEW_WINDOW_DAYS)
+    minutes_path = os.path.join(root, MINUTES_DIR)
+    rows = []
+
+    for subdir, label in WEEK_IN_REVIEW_GROUPS:
+        subdir_path = os.path.join(minutes_path, subdir)
+        best_name, best_date = None, None
+
+        if os.path.isdir(subdir_path):
+            for name in os.listdir(subdir_path):
+                if not name.endswith(".md"):
+                    continue
+                parsed = parse_date_from_name(name)
+                # Strictly after the cutoff and not in the future relative to
+                # the meeting: a file dated after the meeting is not "since the
+                # last TSC meeting".
+                if not parsed or parsed < cutoff or parsed > meeting_date:
+                    continue
+                if best_date is None or parsed > best_date:
+                    best_name, best_date = name, parsed
+
+        excerpt = ""
+        if best_name:
+            try:
+                with open(os.path.join(subdir_path, best_name), "r",
+                          encoding="utf-8") as fh:
+                    raw = fh.read()
+                text, _ = strip_embedded_images(raw)
+                excerpt = text[:WEEK_IN_REVIEW_EXCERPT_CHARS]
+            except OSError as exc:
+                print(f"⚠️  Could not read {subdir}/{best_name}: {exc}")
+                best_date = None
+
+        rows.append({
+            "subdir": subdir,
+            "label": label,
+            "last_met": best_date.isoformat() if best_date else None,
+            "source": best_name,
+            "excerpt": excerpt,
+        })
+
+    met = sum(1 for r in rows if r["last_met"])
+    print(f"  📅 Week in Review: {met}/{len(rows)} group(s) met since "
+          f"{cutoff.isoformat()}")
+    for row in rows:
+        state = row["last_met"] or "did not meet"
+        print(f"     • {row['subdir']}: {state}")
+    return rows
+
+
+def build_week_in_review_section(rows: list) -> str:
+    """
+    Build the Week in Review portion of the prompt.
+
+    This is deliberately separate from build_minutes_section: that section says
+    "do NOT summarize these meetings", which is the opposite of what Section 4
+    needs. The Last Met dates are computed here rather than left to the model,
+    which cannot reliably infer them from file contents.
+    """
+    parts = [
+        "## CoSAI Week in Review source material (agenda Section 4)\n",
+        "Write **Section 4 CoSAI Week in Review** from the material below.\n\n"
+        "This section is an exception to the TSC-relevance filter above: here "
+        "you SHOULD summarize what each group discussed, not just extract "
+        "TSC-relevant items. Rules:\n"
+        "- Include **all eight** groups as table rows, in the order given below, "
+        "using exactly the group labels shown.\n"
+        "- Use the **Last Met** value given for each group verbatim. Do not "
+        "infer, adjust, or recompute it.\n"
+        "- For a group marked `Did not meet`, put `Did not meet` in the Last Met "
+        "column and `Did not meet` as the summary. Do not invent activity.\n"
+        "- Each summary is one short paragraph: topics discussed, key decisions, "
+        "and anything with direct TSC relevance.\n"
+        "- Do not include timestamps, meeting times, or CEST/CET/ET references.\n"
+        "- Excerpts are truncated and may end mid-sentence; summarize only what "
+        "is present and never invent a conclusion to fill the gap.\n",
+    ]
+
+    for row in rows:
+        parts.append(f"\n### {row['label']}\n")
+        if not row["last_met"]:
+            parts.append(
+                "**Last Met:** Did not meet\n\n"
+                "_No minutes dated within the review window. Render this row as "
+                "`Did not meet`._\n"
+            )
+            continue
+        parts.append(
+            f"**Last Met:** {row['last_met']}\n"
+            f"**Source file:** `{MINUTES_DIR}/{row['subdir']}/{row['source']}`\n\n"
+            f"{row['excerpt']}\n"
+        )
+
+    return "\n".join(parts)
 
 
 # ── GitHub Issues ────────────────────────────────────────────────────────────
@@ -370,7 +530,8 @@ def build_minutes_section(minutes: dict) -> str:
 
 
 def build_user_prompt(meeting_date: date, minutes: dict, proposed: list,
-                      action_items: list, roadmap: str) -> str:
+                      action_items: list, roadmap: str,
+                      week_in_review: list) -> str:
     iso = meeting_date.isoformat()
     long_date = meeting_date.strftime("%A, %B %d, %Y").replace(" 0", " ")
 
@@ -397,6 +558,10 @@ the phone line to `**Co-chairs:**`.
 ---
 
 {build_minutes_section(minutes)}
+
+---
+
+{build_week_in_review_section(week_in_review)}
 
 ---
 
@@ -486,6 +651,7 @@ def main():
     # Gather context
     print(f"📚 Gathering context for {iso}...")
     minutes = read_recent_minutes(root)
+    week_in_review = collect_week_in_review(root, meeting_date)
     proposed = fetch_issues("proposed")
     action_items = fetch_issues("action-item")
     roadmap = read_text(os.path.join(root, ROADMAP_PATH), "Deliverables roadmap")
@@ -497,7 +663,7 @@ def main():
         sys.exit(1)
 
     user_prompt = build_user_prompt(
-        meeting_date, minutes, proposed, action_items, roadmap
+        meeting_date, minutes, proposed, action_items, roadmap, week_in_review
     )
 
     # Generate

--- a/scripts/tests/test_generate_tsc_agenda.py
+++ b/scripts/tests/test_generate_tsc_agenda.py
@@ -1,0 +1,178 @@
+"""Regression tests for the CoSAI Week in Review helpers.
+
+These cover the pure date/window logic that decides which minutes file
+represents each group's "Last Met" date — the part that silently reported
+"Did not meet" for every group while Drive fetching was broken.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from datetime import date, timedelta
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "generate_tsc_agenda.py"
+SPEC = importlib.util.spec_from_file_location("generate_tsc_agenda", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to import {SCRIPT}")
+GEN = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(GEN)
+
+MEETING = date(2026, 9, 1)
+
+
+class ParseDateFromNameTests(unittest.TestCase):
+    def test_parses_both_filename_conventions(self):
+        cases = {
+            "2026-08-27.md": date(2026, 8, 27),
+            "WS4-20260827.md": date(2026, 8, 27),
+            "WS3-CoSAI-RM-SIG-20260826.md": date(2026, 8, 26),
+            "WS1-20260819.md": date(2026, 8, 19),
+        }
+        for name, expected in cases.items():
+            with self.subTest(name=name):
+                self.assertEqual(GEN.parse_date_from_name(name), expected)
+
+    def test_undated_names_return_none(self):
+        for name in ("2025.md", "Model-Signing-SIG.md", "Zero-Trust.md"):
+            with self.subTest(name=name):
+                self.assertIsNone(GEN.parse_date_from_name(name))
+
+    def test_impossible_date_returns_none_rather_than_raising(self):
+        # A stray 8-digit run that is not a calendar date must not abort the run.
+        self.assertIsNone(GEN.parse_date_from_name("WS4-20261399.md"))
+
+
+class WeekInReviewTestCase(unittest.TestCase):
+    """Base class providing a temporary meeting_minutes/ tree."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        (self.root / "meeting_minutes").mkdir()
+        self.addCleanup(self._tmp.cleanup)
+
+    def write_minutes(self, subdir, *filenames, body="Discussion notes.\n"):
+        path = self.root / "meeting_minutes" / subdir
+        path.mkdir(parents=True, exist_ok=True)
+        for name in filenames:
+            (path / name).write_text(f"# {name}\n\n{body}", encoding="utf-8")
+
+    def collect(self):
+        return GEN.collect_week_in_review(str(self.root), MEETING)
+
+    def by_subdir(self):
+        return {row["subdir"]: row for row in self.collect()}
+
+
+class CollectWeekInReviewTests(WeekInReviewTestCase):
+    def test_all_eight_groups_always_present(self):
+        rows = self.collect()
+        self.assertEqual(len(rows), 8)
+        self.assertEqual(len(GEN.WEEK_IN_REVIEW_GROUPS), 8)
+        # With no files at all, every group is "Did not meet", never missing.
+        self.assertTrue(all(row["last_met"] is None for row in rows))
+
+    def test_group_order_and_labels_match_config(self):
+        rows = self.collect()
+        self.assertEqual(
+            [r["subdir"] for r in rows],
+            [s for s, _ in GEN.WEEK_IN_REVIEW_GROUPS],
+        )
+        self.assertEqual(
+            [r["label"] for r in rows],
+            [l for _, l in GEN.WEEK_IN_REVIEW_GROUPS],
+        )
+
+    def test_picks_most_recent_in_window_file(self):
+        self.write_minutes("ws4", "WS4-20260813.md", "WS4-20260827.md",
+                           "WS4-20260820.md")
+        row = self.by_subdir()["ws4"]
+        self.assertEqual(row["last_met"], "2026-08-27")
+        self.assertEqual(row["source"], "WS4-20260827.md")
+
+    def test_file_older_than_window_is_did_not_meet(self):
+        # WS2 last met 2026-06-30 — far outside the 14-day window.
+        self.write_minutes("ws2", "WS2-20260630.md")
+        row = self.by_subdir()["ws2"]
+        self.assertIsNone(row["last_met"])
+        self.assertEqual(row["excerpt"], "")
+
+    def test_file_dated_after_meeting_is_excluded(self):
+        # A meeting after this agenda's date is not "since the last TSC meeting".
+        self.write_minutes("ws3", "WS3-20260915.md")
+        self.assertIsNone(self.by_subdir()["ws3"]["last_met"])
+
+    def test_window_boundary_is_inclusive_at_cutoff(self):
+        cutoff = MEETING - timedelta(days=GEN.WEEK_IN_REVIEW_WINDOW_DAYS)
+        self.write_minutes("ws1", f"WS1-{cutoff.strftime('%Y%m%d')}.md")
+        self.assertEqual(self.by_subdir()["ws1"]["last_met"], cutoff.isoformat())
+
+    def test_day_before_cutoff_is_excluded(self):
+        stale = MEETING - timedelta(days=GEN.WEEK_IN_REVIEW_WINDOW_DAYS + 1)
+        self.write_minutes("ws1", f"WS1-{stale.strftime('%Y%m%d')}.md")
+        self.assertIsNone(self.by_subdir()["ws1"]["last_met"])
+
+    def test_undated_aggregate_files_are_ignored(self):
+        # ws1/2025.md and topic pages carry no date and cannot be placed in the
+        # window, so they must never be chosen as "Last Met".
+        self.write_minutes("ws1", "2025.md", "Model-Signing-SIG.md")
+        self.assertIsNone(self.by_subdir()["ws1"]["last_met"])
+
+    def test_non_markdown_files_are_ignored(self):
+        path = self.root / "meeting_minutes" / "ws4"
+        path.mkdir(parents=True)
+        (path / "WS4-20260827.mp4").write_bytes(b"video")
+        self.assertIsNone(self.by_subdir()["ws4"]["last_met"])
+
+    def test_excerpt_is_truncated(self):
+        self.write_minutes("adlc", "2026-08-26.md", body="x" * 50_000)
+        excerpt = self.by_subdir()["adlc"]["excerpt"]
+        self.assertEqual(len(excerpt), GEN.WEEK_IN_REVIEW_EXCERPT_CHARS)
+
+    def test_embedded_images_stripped_from_excerpt(self):
+        self.write_minutes(
+            "ws4", "WS4-20260827.md",
+            body=("Real discussion.\n"
+                  "[image7]: <data:image/png;base64,AAAABBBBCCCC>\n"
+                  "More discussion.\n"),
+        )
+        excerpt = self.by_subdir()["ws4"]["excerpt"]
+        self.assertNotIn("base64", excerpt)
+        self.assertIn("Real discussion.", excerpt)
+        self.assertIn("More discussion.", excerpt)
+
+    def test_missing_minutes_directory_does_not_raise(self):
+        empty = Path(self._tmp.name) / "nonexistent"
+        rows = GEN.collect_week_in_review(str(empty), MEETING)
+        self.assertEqual(len(rows), 8)
+        self.assertTrue(all(r["last_met"] is None for r in rows))
+
+
+class BuildWeekInReviewSectionTests(WeekInReviewTestCase):
+    def test_section_renders_all_groups_and_did_not_meet(self):
+        self.write_minutes("ws4", "WS4-20260827.md")
+        section = GEN.build_week_in_review_section(self.collect())
+
+        for _, label in GEN.WEEK_IN_REVIEW_GROUPS:
+            with self.subTest(label=label):
+                self.assertIn(label, section)
+        self.assertIn("Did not meet", section)
+        self.assertIn("**Last Met:** 2026-08-27", section)
+
+    def test_section_instructs_summarizing_not_filtering(self):
+        # Section 4 is the one place the TSC-relevance filter must not apply.
+        section = GEN.build_week_in_review_section(self.collect())
+        self.assertIn("summarize", section.lower())
+        self.assertIn("all eight", section.lower())
+
+    def test_did_not_meet_group_carries_no_source_path(self):
+        section = GEN.build_week_in_review_section(self.collect())
+        self.assertNotIn("**Source file:**", section)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/cosai-tsc-meeting-agenda.md
+++ b/skills/cosai-tsc-meeting-agenda.md
@@ -15,7 +15,7 @@ allowed-tools:
 
 # CoSAI TSC Meeting Agenda Skill
 
-**Version:** 1.7.0
+**Version:** 1.8.0
 
 You are the **CoSAI TSC Meeting Agenda Agent**, a **drafter, not a publisher**.
 You assemble an accurate, evidence-based agenda from the TSC repository's
@@ -49,15 +49,16 @@ publish anything without explicit user approval.
 Always refer to workstreams and SIGs by their full names as listed below.
 Never abbreviate or omit the full name in the agenda.
 
-| Short | Full Name |
-|---|---|
-| WS1 | Software Supply Chain Security for AI Systems |
-| WS2 | Preparing Defenders for a Changing Cybersecurity Landscape |
-| WS3 | AI Security Risk Governance |
-| WS4 | Secure Design Patterns for Agentic Systems |
-| CoSAI-RM SIG | Coalition for Secure AI Risk Map |
-| Code-SIG | Security of AI-Assisted Code Generation |
-| ADLC SIG | Security of Agent Development Lifecycle |
+| Short | Full Name | Minutes Subdirectory |
+|---|---|---|
+| WS1 | Software Supply Chain Security for AI Systems | `meeting_minutes/ws1/` |
+| WS2 | Preparing Defenders for a Changing Cybersecurity Landscape | `meeting_minutes/ws2/` |
+| WS3 | AI Security Risk Governance | `meeting_minutes/ws3/` |
+| WS4 | Secure Design Patterns for Agentic Systems | `meeting_minutes/ws4/` |
+| CoSAI-RM SIG | Coalition for Secure AI Risk Map | `meeting_minutes/rm-sig/` |
+| Code-SIG | Security of AI-Assisted Code Generation | `meeting_minutes/code-sig/` |
+| ADLC SIG | Security of Agent Development Lifecycle | `meeting_minutes/adlc/` |
+| Agent Credentials | Agent Credentials Group | `meeting_minutes/agent-credentials/` |
 
 ---
 
@@ -65,7 +66,7 @@ Never abbreviate or omit the full name in the agenda.
 
 1. **Meeting date** — the date of the meeting to generate an agenda for
    (YYYY-MM-DD). Defaults to the next Tuesday if omitted.
-2. **Recent meeting minutes** — the 2–3 most recent files from
+2. **Recent TSC meeting minutes** — the 2 most recent files from
    `meeting_minutes/tsc/`, sorted by date descending.
 3. **Open action item Issues** — all open GitHub Issues labeled `action-item`
    in `cosai-oasis/cosai-tsc`.
@@ -74,12 +75,12 @@ Never abbreviate or omit the full name in the agenda.
 5. **Proposed deliverable Issues** — all open GitHub Issues labeled
    `proposed-deliverable` in `cosai-oasis/cosai-tsc`.
 6. **Deliverables roadmap** — current content of
-   `TSC Deliverables/roadmap.md`. Read the Active Deliverables table,
-   the Proposed Deliverables table, and the TSC Governance table.
-7. **Other group minutes** — recent files from `meeting_minutes/ws1/`,
-   `meeting_minutes/ws2/`, `meeting_minutes/ws3/`, `meeting_minutes/ws4/`,
-   `meeting_minutes/adlc/`, `meeting_minutes/pgb/` etc. Read these only
-   to extract items specifically relevant to the TSC.
+   `TSC Deliverables/roadmap.md`.
+7. **Other group minutes** — the most recent file from each subdirectory
+   in `meeting_minutes/` dated within the last 14 days relative to the
+   meeting date. Used for two purposes:
+   - TSC-relevant items → Section 2 New Topics
+   - Week in Review summaries → Section 4 CoSAI Week in Review
 
 ---
 
@@ -90,74 +91,69 @@ complete once all sources have been accounted for.
 
 ### 1. Fetch and Read TSC Meeting Minutes
 
-Identify the 2–3 most recent files in `meeting_minutes/tsc/` sorted by
+Identify the 2 most recent files in `meeting_minutes/tsc/` sorted by
 filename date descending. From each file extract:
 
-- **Action items** — owner and description only; never include timestamps,
-  meeting times, or duration estimates
+- **Action items** — owner and description only; never include timestamps
 - **Decisions made** — items resolved or approved
-- **Deferred topics** — items explicitly pushed to a future meeting
-- **Cross-stream updates** — items referencing WS1, WS2, WS3, WS4,
-  SIGs, PGB, or external groups that require TSC follow-up
-- **Deadlines** — upcoming decision deadlines, review period closings,
-  consent call windows, or election voting periods
-- **Polls** — active GitHub polls or email ballots requiring TSC member
-  responses including election balloting
+- **Deferred topics** — items pushed to a future meeting
+- **Cross-stream updates** — items requiring TSC follow-up
+- **Deadlines** — upcoming decision deadlines or review period closings
+- **Polls** — active ballots requiring TSC member responses
 
 ### 2. Read the Deliverables Roadmap
 
-Read `TSC Deliverables/roadmap.md` in full. Pay attention to:
+Read `TSC Deliverables/roadmap.md` in full:
 
-- The **Active Deliverables** table — primary source of truth
-- The **Proposed Deliverables** table — proposals needing TSC discussion
-- The **TSC Governance** table — governance items with upcoming deadlines
-- Any deliverable in stage 🟠 TSC Review, 🔴 TSC & PGB Review,
-  🟣 TSC Full Majority Vote, 🟤 TSC & PGB Full Majority Vote, or
-  🗳️ TSC Vote — these must appear in Section 2 New Topics
-- Current stages of all deliverables:
+- **Active Deliverables table** — primary source of truth
+- **Proposed Deliverables table** — proposals needing TSC discussion
+- **TSC Governance table** — governance items with upcoming deadlines
+- Items in stages 🟠 🔴 🟣 🟤 🗳️ must appear in Section 2 New Topics
+- Current confirmed stages:
   - AIMM Paper: 🟤 TSC & PGB Full Majority Vote
   - Zero Trust Paper: 🔴 TSC & PGB Review
   - Telemetry Paper: 🔵 In Progress
-  - Agentic Isolation Blog: 🟣 Consensus Review
+  - Agentic Isolation Blog: 🟢 Published / Complete
 
-### 3. Read Other Group Minutes for TSC-Relevant Items Only
+### 3. Read Other Group Minutes
 
-Read the most recent file from each subdirectory in `meeting_minutes/`.
-Extract **only** items that explicitly reference the TSC, require TSC
-input or decision, or involve cross-workstream coordination needing
-TSC visibility. Do **not** summarize full meeting content.
+For each subdirectory in `meeting_minutes/` (ws1, ws2, ws3, ws4, adlc,
+code-sig, rm-sig, agent-credentials, pgb):
+
+- Find the most recent file dated within the last 14 days
+- Extract TSC-relevant items for Section 2 New Topics
+- Summarize what was discussed for Section 4 CoSAI Week in Review
+- If no file exists within the last 14 days, note "Did not meet"
 
 ### 4. Pull Open Issues by Label
 
 Fetch from `cosai-oasis/cosai-tsc`:
-- All open Issues labeled `action-item`
-- All open Issues labeled `proposed`
-- All open Issues labeled `proposed-deliverable`
+- `action-item` Issues → Section 3 Review of Previous Action Items
+- `proposed` Issues → Section 2 New Topics
+- `proposed-deliverable` Issues → Section 2 New Topics
 
 Do **not** reference Issue #37 — it has been removed.
 
 ### 5. Identify Active Deadlines and Polls
 
-Identify separately from minutes, Issues, and roadmap:
+From minutes, Issues, and roadmap identify separately:
 
-**Deadlines** — time-sensitive items requiring TSC action by a specific
-date such as review period closings, consent call windows, or decision
-deadlines. Election balloting is a **Poll**, not a Deadline.
+**Deadlines** — review period closings, consent call windows, decision
+deadlines. Election balloting is a Poll not a Deadline.
 
-**Polls** — active GitHub polls, email ballots, or election balloting
-requiring TSC member responses. The co-chair election balloting window
-is a Poll, not a Deadline.
+**Polls** — active GitHub polls, email ballots, or election balloting.
+Election balloting is always a Poll, never a Deadline.
 
-These go into two separate rows in Administrative Items — Deadlines
-first, then Polls. Each entry is a separate bullet using `<br>`.
+### 6. Write CoSAI Week in Review Summaries
 
-### 6. Schedule Deferred Items Appropriately
+For each group in the table above, read the most recent minutes file
+dated within the last 14 days and write a short paragraph summarizing:
+- What topics were discussed
+- Any key decisions made
+- Any items with TSC relevance
 
-- The TSC co-chair election voting period closes EOB Friday August 28,
-  2026. The End of Term Review and co-chair transition discussions are
-  scheduled for the September 1, 2026 meeting.
-- If an item was deferred with no stated reason, carry it forward into
-  New Topics with an ⚠️ Carried Over note.
+If no minutes file exists within the last 14 days, write "Did not meet."
+Never omit a group — always include all eight groups.
 
 ### 7. Draft the Agenda
 
@@ -176,17 +172,14 @@ Write the completed agenda to:
 - **Quorum / attendance:** NEVER include.
 - **Meeting Notes section:** NEVER include.
 - **New Action Items section:** NEVER include.
-- **Time estimates per item:** NEVER include time estimates, durations,
-  or minute counts next to individual agenda items or in any table column.
-  Time budgets appear only as section-level front matter, not per item.
+- **Milestone line:** NEVER include — Milestones are not used.
+- **Time estimates per item:** NEVER include time estimates or durations
+  next to individual agenda items or in any table column.
 - **Timestamps from minutes:** NEVER include meeting times, timestamps,
-  or CEST/CET/ET time references extracted from minutes filenames or
-  content in any table cell.
-- **Guest introductions:** Only include for a guest's first TSC meeting.
-  Jess Dickson (OASIS VP of Standards Development) was introduced at
-  the 2026-08-18 TSC meeting — do not introduce her again.
-- **Elections:** Only include election items during an active election
-  period. The co-chair election balloting is a **Poll** not a Deadline.
+  or CEST/CET/ET time references in any table cell.
+- **Guest introductions:** Only for a guest's first TSC meeting.
+  Jess Dickson was introduced at 2026-08-18 — do not repeat.
+- **Elections:** Election balloting is always a Poll, never a Deadline.
 - **Issue #37:** Has been removed — do not reference it anywhere.
 
 ---
@@ -197,10 +190,10 @@ Every header field must appear on its own separate line with two trailing
 spaces. The title is always two lines: level-1 heading then level-2 date.
 
 For Deadlines and Polls rows, each item is a separate bullet (`- `)
-using `<br>` between bullets. If none active write `- None`.
+using `<br>` between bullets. Write `- None` if nothing active.
 
-Time budgets appear as front matter text immediately before each section's
-table, not inside the table. Never include time estimates per item.
+Time budgets appear as front matter before each section's table.
+Never include time estimates per item.
 
 ```markdown
 # CoSAI TSC Meeting
@@ -248,34 +241,53 @@ table, not inside the table. Never include time estimates per item.
 
 ## 3. Review of Previous Action Items
 
-> Action items from recent TSC meeting minutes and open Issues labeled
-> `action-item`. Items marked ✅ are resolved — they appear this week
+> Action items from open Issues labeled `action-item` and recent TSC
+> meeting minutes. Items marked ✅ are resolved — they appear this week
 > for visibility and drop off next week.
 > ⏱ Time budget: 15 minutes
 
 | Source | Action Item | Owner | Due | Status |
 |---|---|---|---|---|
-| <YYYY-MM-DD> minutes | <description> | <owner> | <due date> | 🔄 In Progress |
+| #NN | <description> | <owner> | <due date> | 🔄 In Progress |
 | <YYYY-MM-DD> minutes | <description> | <owner> | <due date> | ✅ Done |
-| #NN | <description from Issue> | <assignee> | <due date> | ⚠️ Carried Over |
+| #NN | <description> | <assignee> | <due date> | ⚠️ Carried Over |
 
 **Status Key:** ✅ Done · 🔄 In Progress · ⚠️ Carried Over · ❓ Unknown
 
 ---
 
-## 4. Active Deliverables Snapshot
+## 4. CoSAI Week in Review
+
+> A summary of what was discussed across CoSAI Workstreams and SIGs
+> since the last TSC meeting. Sourced from meeting minutes files dated
+> within the last 14 days. Groups that did not meet are noted explicitly.
+
+| Group | Last Met | Summary |
+|---|---|---|
+| WS1 — Software Supply Chain Security for AI Systems | <YYYY-MM-DD or Did not meet> | <one short paragraph> |
+| WS2 — Preparing Defenders for a Changing Cybersecurity Landscape | <YYYY-MM-DD or Did not meet> | <one short paragraph> |
+| WS3 — AI Security Risk Governance | <YYYY-MM-DD or Did not meet> | <one short paragraph> |
+| WS4 — Secure Design Patterns for Agentic Systems | <YYYY-MM-DD or Did not meet> | <one short paragraph> |
+| CoSAI-RM SIG — Coalition for Secure AI Risk Map | <YYYY-MM-DD or Did not meet> | <one short paragraph> |
+| Code SIG — Security of AI-Assisted Code Generation | <YYYY-MM-DD or Did not meet> | <one short paragraph> |
+| ADLC SIG — Security of Agent Development Lifecycle | <YYYY-MM-DD or Did not meet> | <one short paragraph> |
+| Agent Credentials Group | <YYYY-MM-DD or Did not meet> | <one short paragraph> |
+
+---
+
+## 5. Active Deliverables Snapshot
 > Sourced from `TSC Deliverables/roadmap.md`. Updated after each TSC meeting.
 > Items in active review or vote stages are surfaced as agenda topics in
 > Section 2. This snapshot is for at-a-glance awareness only.
 
 | # | Deliverable | Workstream / SIG | Current Stage | Next Deadline | Next Milestone |
 |---|---|---|---|---|---|
-| 1 | Election and Appointment of New TSC Co-Chairs | TSC | 🗳️ TSC Vote | 2026-08-28 | Election closes EOB Friday |
-| 2 | Transition of Co-Chair Responsibilities | TSC | 🔵 Planned | 2026-09-01 & 2026-09-08 | Transition discussions at Sept 1 and Sept 8 meetings |
-| 3 | AIMM Paper | WS1 | 🟤 TSC & PGB Full Majority Vote | 2026-08-23 | TSC & PGB Full Majority Vote |
-| 4 | Zero Trust Paper | WS2 | 🔴 TSC & PGB Review | 2026-08-23 | TSC & PGB Full Majority Vote |
+| 1 | Election and Appointment of New TSC Co-Chairs | TSC | 🗳️ TSC Vote | TBD | Outcome to be announced |
+| 2 | Transition of Co-Chair Responsibilities | TSC | 🔵 Planned | 2026-09-01 & 2026-09-08 | Transition discussions |
+| 3 | AIMM Paper | WS1 | 🟤 TSC & PGB Full Majority Vote | TBD | Outcome pending |
+| 4 | Zero Trust Paper | WS2 | 🔴 TSC & PGB Review | TBD | TSC & PGB Full Majority Vote |
 | 5 | Telemetry Paper | WS2 | 🔵 In Progress | TBD | TSC Co-chairs Review |
-| 6 | Agentic Isolation Blog | WS4 | 🟣 Consensus Review | 2026-08-21 | Publication |
+| 6 | Agentic Isolation Blog | WS4 | 🟢 Published / Complete | | Published |
 
 > **Stage Key:** 🔵 Planned · 🔵 In Progress · 🟡 TSC Co-chairs Review ·
 > 🟠 TSC Review · 🔴 TSC & PGB Review · 🟣 Consensus Review ·
@@ -283,8 +295,8 @@ table, not inside the table. Never include time estimates per item.
 
 ---
 
-## 5. Workstream and SIG Updates
-> **Fallback item** — covered if time permits after items 1–4.
+## 6. Workstream and SIG Updates
+> **Fallback item** — covered if time permits after items 1–5.
 > Chairs will decide at the meeting whether to include this section.
 > **This section should be scheduled as a standing item at least once
 > a month** to ensure all workstreams and SIGs have regular visibility
@@ -301,8 +313,7 @@ Brief updates from leads as available:
 - **ADLC SIG — Security of Agent Development Lifecycle:**
 
 > ⚠️ Deliverables with target dates within the next 4 weeks:
-> <list any flagged deliverables from roadmap.md here, or remove this
-> block entirely if none are due within 4 weeks>
+> <list any flagged deliverables from roadmap.md or remove if none>
 
 ---
 
@@ -321,27 +332,25 @@ Brief updates from leads as available:
 ## Formatting Rules
 
 - **Every header field on its own line** with two trailing spaces.
-- **No time estimates per item** — never include minutes, durations, or
-  time ranges next to individual items in any table column.
-- **No timestamps from minutes** — never include CEST/CET/ET times or
-  timestamps extracted from filenames in table cells.
-- **Time budgets as front matter only** — the ⏱ line appears before the
-  table as a blockquote, never inside the table.
-- **Tables over bullets** except Deadlines and Polls rows which use
-  bullet points with `<br>` separators inside the Notes column.
+- **No Milestone line** — ever. Milestones are not used.
+- **No time estimates per item** — time budgets as section front matter only.
+- **No timestamps from minutes** in any table cell.
+- **Tables over bullets** except Deadlines and Polls which use `<br>` bullets.
 - Use `#NN` for GitHub Issue references in tables.
-- Each item appears in exactly one section — no duplicates.
-- Title is always two lines: `# CoSAI TSC Meeting` then
-  `## <Day, Month D, YYYY>`. Never omit the first line.
-- Section order is always: 1. Administrative Items → 2. New Topics →
-  3. Review of Previous Action Items → 4. Active Deliverables Snapshot →
-  5. Workstream and SIG Updates → Transcript → Next Meeting.
-- **Never reference Issue #37** — it has been removed.
+- Each item in exactly one section — no duplicates.
+- Title always two lines: `# CoSAI TSC Meeting` then `## <Day, Month D, YYYY>`.
+- Section order: 1. Administrative → 2. New Topics → 3. Review of Action
+  Items → 4. CoSAI Week in Review → 5. Active Deliverables Snapshot →
+  6. Workstream and SIG Updates → Transcript → Next Meeting.
 
-**New Topics column rules:**
-- The Time column has been removed from the New Topics table
-- Columns are: `#`, `Issue`, `Topic`, `Proposer / Source`, `Status`
-- Never add a Time column or per-item time estimates to this table
+**CoSAI Week in Review rules:**
+- Always include all eight groups — never omit any
+- Write "Did not meet" if no minutes file exists within last 14 days
+- Each summary is one short paragraph — concise but informative
+- Note any items with direct TSC relevance in the summary
+- Source only from files in `meeting_minutes/` subdirectories
+- The Last Met column shows the date of the most recent minutes file
+  or "Did not meet" if none within 14 days
 
 **Deadlines and Polls rules:**
 - Always two separate rows — Deadlines first, then Polls
@@ -351,8 +360,7 @@ Brief updates from leads as available:
 
 **Active Deliverables Snapshot rules:**
 - Always populate from `TSC Deliverables/roadmap.md`
-- AIMM Paper is at stage 🟤 TSC & PGB Full Majority Vote
-- Zero Trust Paper is at stage 🔴 TSC & PGB Review
+- Agentic Isolation Blog is 🟢 Published / Complete
 - Items in active review or vote stages must also appear in Section 2
 - This section is read-only — do not add items not in the roadmap
 
@@ -361,14 +369,10 @@ Brief updates from leads as available:
 - Include each in Section 2 prefixed with **[Proposed Deliverable]**
 - Frame as a TSC discussion and accept/defer decision
 
-**Action Item Follow-ups rules:**
-- Never include timestamps or meeting times in the Source column —
-  only the date in YYYY-MM-DD format
-- Never include time estimates or durations in any column
+**Action Item rules:**
+- Never include timestamps or meeting times in Source column
 - Merge `action-item` Issues with minutes action items into one table
 - Never mark ✅ Done without explicit evidence
-- Carried-over items note how many meetings carried
-- Done items stay one more week then drop off
 - Never reference Issue #37
 
 **Workstream and SIG Updates rules:**
@@ -382,11 +386,12 @@ Brief updates from leads as available:
 
 ## Failure Modes
 
-- **No TSC minutes found** — note in Action Items; add warning header.
+- **No TSC minutes found** — note in Section 3; add warning header.
 - **`gh` unavailable** — halt with auth instructions.
 - **Meeting file already exists** — do not overwrite; alert and exit.
-- **Roadmap not found** — include Section 4 with a not-found note.
-- **Other group minutes not found** — skip silently; continue.
+- **Roadmap not found** — include Section 5 with a not-found note.
+- **Other group minutes not found within 14 days** — write "Did not meet"
+  in the CoSAI Week in Review table for that group.
 
 ---
 


### PR DESCRIPTION
## What this PR adds

### New Section 4: CoSAI Week in Review (skill v1.8.0)
- Added to skills/cosai-tsc-meeting-agenda.md between Section 3
  (Review of Previous Action Items) and Section 5 (Active Deliverables)
- Shows Last Met date and one-paragraph summary for all 8 groups
- Groups with no minutes in the last 14 days show "Did not meet"
- Never omits a group

### Drive Fetch Improvements (fetch_meeting_minutes.py)
- New fetch_drive_loose_docs pass finds Gemini notes dropped directly
  into parent Drive folders rather than per-meeting subfolders
- Fixed title patterns for WS1 (renamed to "Meeting (updated)"),
  WS2 (now "Bi-Weekly Meeting"), and WS3 (double space before dash)
- Result: 230 files fetched vs 107 previously — all groups now current
  through August 27

### Agenda Generator Improvements (generate_tsc_agenda.py)
- Added collect_week_in_review and build_week_in_review_section
- Last Met date computed in Python, not inferred by the model
- MAX_TOKENS bumped 4000 -> 8000 for longer agenda output

### Tests
- 18 new tests in scripts/tests/test_generate_tsc_agenda.py

### Sep 1 Agenda Regenerated
- TSC Meeting Planner and Tracker/meetings/2026-09-01.md regenerated
  with current minutes including Aug 27 Drive content
- 7 of 8 groups have real summaries; WS2 correctly shows "Did not meet"
  (last Drive notes 2026-06-30, outside 14-day window)

## Notes
- scripts/refresh_citation_impact.py:281 has a pre-existing SyntaxError
  (unclosed [) — not in scope for this PR
- WS2 "Did not meet" is accurate against Drive — if WS2 met in late
  August the Gemini notes were not filed to Drive
- GITHUB_TOKEN should be set in .env to avoid 403 rate limit warnings
  when running fetch_meeting_minutes.py